### PR TITLE
Add a wrapper to ZMUMPS (double complex arithmetic) and an example

### DIFF
--- a/examples/dsimpletest.py
+++ b/examples/dsimpletest.py
@@ -12,6 +12,7 @@ import numpy as np
 import mumps
 
 # Set up the test problem:
+# irn and jcn are 1-based, not 0-based
 n = 5
 irn = np.array([1,2,4,5,2,1,5,3,2,3,1,3], dtype='i')
 jcn = np.array([2,3,3,5,1,1,2,4,5,2,3,3], dtype='i')
@@ -22,7 +23,7 @@ b = np.array([20.0,24.0,9.0,6.0,13.0], dtype='d')
 # Create the MUMPS context and set the array and right hand side
 ctx = mumps.DMumpsContext(sym=0, par=1)
 if ctx.myid == 0:
-    ctx.set_shape(5)
+    ctx.set_shape(n)
     ctx.set_centralized_assembled(irn, jcn, a)
     x = b.copy()
     ctx.set_rhs(x)

--- a/examples/zsimpletest.py
+++ b/examples/zsimpletest.py
@@ -1,0 +1,50 @@
+"""
+ZMUMPS test routine.
+
+Run as:
+    mpirun -np 2 python zsimpletest.py
+or
+    mpiexec -np 2 python zsimpletest.py
+
+The solution should be
+
+  -0.0020 + 0.0078j
+  -0.0067 + 0.0066j
+  -0.0087 + 0.0028j
+  -0.0073 - 0.0022j
+  -0.0029 - 0.0063j
+   0.0027 - 0.0079j
+  -0.0029 - 0.0063j
+  -0.0073 - 0.0022j
+  -0.0087 + 0.0028j
+  -0.0067 + 0.0066j
+  -0.0020 + 0.0078j
+"""
+
+import numpy as np
+import mumps
+
+# Set up the test problem:
+# irn and jcn are 1-based, not 0-based
+n = 11
+irn = np.array([1      ,1 ,2 ,2   ,2 ,3 ,3   ,3 ,4 ,4   ,4 ,5 ,5   ,5 ,6 ,6   ,6 ,7 ,7   ,7 ,8 ,8   ,8 ,9 ,9   ,9 ,10,10  ,10,11 ,11    ], dtype='i')
+jcn = np.array([1      ,2 ,1 ,2   ,3 ,2 ,3   ,4 ,3 ,4   ,5 ,4 ,5   ,6 ,5 ,6   ,7 ,6 ,7   ,8 ,7 ,8   ,9 ,8 ,9   ,10,9 ,10  ,11,10 ,11    ], dtype='i')
+a   = np.array([-1.-.6j,1.,1.,-1.6,1.,1.,-1.6,1.,1.,-1.6,1.,1.,-1.6,1.,1.,-1.6,1.,1.,-1.6,1.,1.,-1.6,1.,1.,-1.6,1.,1.,-1.6,1.,-1.,1.+.6j], dtype='D')
+b = np.array([0.,0.,0.,0.,0.,-.01,0.,0.,0.,0.,0.], dtype='D')
+
+# Create the MUMPS context and set the array and right hand side
+ctx = mumps.ZMumpsContext(sym=0, par=1)
+if ctx.myid == 0:
+    ctx.set_shape(n)
+    ctx.set_centralized_assembled(irn, jcn, a)
+    x = b.copy()
+    ctx.set_rhs(x)
+
+ctx.set_silent() # Turn off verbose output
+
+ctx.run(job=6) # Analysis + Factorization + Solve
+
+if ctx.myid == 0:
+    print("Solution is %s." % (x,))
+
+ctx.destroy() # Free memory

--- a/mumps/__init__.py
+++ b/mumps/__init__.py
@@ -1,8 +1,10 @@
 import warnings
 import mumps._dmumps
+import mumps._zmumps
 
 __all__ = [
     'DMumpsContext',
+    'ZMumpsContext',
     'spsolve',
     ]
 
@@ -236,6 +238,11 @@ class DMumpsContext(_MumpsBaseContext):
     _mumps_c = staticmethod(_dmumps.dmumps_c)
     _MUMPS_STRUC_C = staticmethod(_dmumps.DMUMPS_STRUC_C)
 
+class ZMumpsContext(_MumpsBaseContext):
+
+    cast_array = staticmethod(_zmumps.cast_array)
+    _mumps_c = staticmethod(_zmumps.zmumps_c)
+    _MUMPS_STRUC_C = staticmethod(_zmumps.ZMUMPS_STRUC_C)
 
 ########################################################################
 # Functions
@@ -244,19 +251,36 @@ class DMumpsContext(_MumpsBaseContext):
 def spsolve(A, b, comm=None):
     """Sparse solve A\b."""
 
-    assert A.dtype == 'd' and b.dtype == 'd', "Only double precision supported."
-    with DMumpsContext(par=1, sym=0, comm=comm) as ctx:
-        if ctx.myid == 0:
-            # Set the sparse matrix -- only necessary on
-            ctx.set_centralized_sparse(A.tocoo())
-            x = b.copy()
-            ctx.set_rhs(x)
+    # assert A.dtype == 'd' and b.dtype == 'd', "Only double precision supported."
+    if A.dtype == 'd' and b.dtype == 'd':
+        with DMumpsContext(par=1, sym=0, comm=comm) as ctx:
+            if ctx.myid == 0:
+                # Set the sparse matrix -- only necessary on
+                ctx.set_centralized_sparse(A.tocoo())
+                x = b.copy()
+                ctx.set_rhs(x)
 
-        # Silence most messages
-        ctx.set_silent()
+            # Silence most messages
+            ctx.set_silent()
 
-        # Analysis + Factorization + Solve
-        ctx.run(job=6)
+            # Analysis + Factorization + Solve
+            ctx.run(job=6)
 
-        if ctx.myid == 0:
-            return x
+            if ctx.myid == 0:
+                return x
+    elif A.dtype == 'z' or b.dtype == 'z':
+        with ZMumpsContext(par=1, sym=0, comm=comm) as ctx:
+            if ctx.myid == 0:
+                # Set the sparse matrix -- only necessary on
+                ctx.set_centralized_sparse(A.tocoo())
+                x = b.copy()
+                ctx.set_rhs(x)
+
+            # Silence most messages
+            ctx.set_silent()
+
+            # Analysis + Factorization + Solve
+            ctx.run(job=6)
+
+            if ctx.myid == 0:
+                return x

--- a/mumps/_zmumps.pyx
+++ b/mumps/_zmumps.pyx
@@ -1,0 +1,344 @@
+__all__ = ['ZMUMPS_STRUC_C', 'zmumps_c', 'cast_array']
+
+########################################################################
+# libzmumps / zmumps_c.h wrappers (using Cython)
+########################################################################
+
+MUMPS_INT_DTYPE = 'i'
+ZMUMPS_REAL_DTYPE = 'D'        # NumPy type code for complex128
+ZMUMPS_COMPLEX_DTYPE = 'D'
+
+from libc.string cimport strncpy
+
+cdef extern from "zmumps_c.h":
+
+    ctypedef int MUMPS_INT
+    ctypedef struct mumps_double_complex:
+        double r
+        double i
+    ctypedef mumps_double_complex ZMUMPS_COMPLEX
+    ctypedef double ZMUMPS_REAL
+
+    char* MUMPS_VERSION
+
+    ctypedef struct c_ZMUMPS_STRUC_C "ZMUMPS_STRUC_C":
+        MUMPS_INT      sym, par, job
+        MUMPS_INT      comm_fortran    # Fortran communicator
+        MUMPS_INT      icntl[40]
+        ZMUMPS_REAL    cntl[15]
+        MUMPS_INT      n
+
+        # used in matlab interface to decide if we
+        # free + malloc when we have large variation
+        MUMPS_INT      nz_alloc
+
+        # Assembled entry
+        MUMPS_INT      nz
+        MUMPS_INT      *irn
+        MUMPS_INT      *jcn
+        ZMUMPS_COMPLEX *a
+
+        # Distributed entry
+        MUMPS_INT      nz_loc
+        MUMPS_INT      *irn_loc
+        MUMPS_INT      *jcn_loc
+        ZMUMPS_COMPLEX *a_loc
+
+        # Element entry
+        MUMPS_INT      nelt
+        MUMPS_INT      *eltptr
+        MUMPS_INT      *eltvar
+        ZMUMPS_COMPLEX *a_elt
+
+        # Ordering, if given by user
+        MUMPS_INT      *perm_in
+
+        # Orderings returned to user
+        MUMPS_INT      *sym_perm    # symmetric permutation
+        MUMPS_INT      *uns_perm    # column permutation
+
+        # Scaling (input only in this version)
+        ZMUMPS_REAL    *colsca
+        ZMUMPS_REAL    *rowsca
+
+        # RHS, solution, ouptput data and statistics
+        ZMUMPS_COMPLEX *rhs, *redrhs, *rhs_sparse, *sol_loc
+        MUMPS_INT      *irhs_sparse, *irhs_ptr, *isol_loc
+        MUMPS_INT      nrhs, lrhs, lredrhs, nz_rhs, lsol_loc
+        MUMPS_INT      schur_mloc, schur_nloc, schur_lld
+        MUMPS_INT      mblock, nblock, nprow, npcol
+        MUMPS_INT      info[40],infog[40]
+        ZMUMPS_REAL    rinfo[20], rinfog[20]
+
+        # Null space
+        MUMPS_INT      deficiency
+        MUMPS_INT      *pivnul_list
+        MUMPS_INT      *mapping
+
+        # Schur
+        MUMPS_INT      size_schur
+        MUMPS_INT      *listvar_schur
+        ZMUMPS_COMPLEX *schur
+
+        # Internal parameters
+        MUMPS_INT      instance_number
+        ZMUMPS_COMPLEX *wk_user
+
+        char *version_number
+        # For out-of-core
+        char *ooc_tmpdir
+        char *ooc_prefix
+        # To save the matrix in matrix market format
+        char *write_problem
+        MUMPS_INT      lwk_user
+    void c_zmumps_c "zmumps_c" (c_ZMUMPS_STRUC_C *) nogil
+
+cdef class ZMUMPS_STRUC_C:
+    cdef c_ZMUMPS_STRUC_C ob
+
+    property sym:
+        def __get__(self): return self.ob.sym
+        def __set__(self, value): self.ob.sym = value
+    property par:
+        def __get__(self): return self.ob.par
+        def __set__(self, value): self.ob.par = value
+    property job:
+        def __get__(self): return self.ob.job
+        def __set__(self, value): self.ob.job = value
+
+    property comm_fortran:
+        def __get__(self): return self.ob.comm_fortran
+        def __set__(self, value): self.ob.comm_fortran = value
+
+    property icntl:
+        def __get__(self):
+            cdef MUMPS_INT[:] view = self.ob.icntl
+            return view
+    property cntl:
+        def __get__(self):
+            cdef ZMUMPS_REAL[:] view = self.ob.cntl
+            return view
+
+    property n:
+        def __get__(self): return self.ob.n
+        def __set__(self, value): self.ob.n = value
+    property nz_alloc:
+        def __get__(self): return self.ob.nz_alloc
+        def __set__(self, value): self.ob.nz_alloc = value
+
+    property nz:
+        def __get__(self): return self.ob.nz
+        def __set__(self, value): self.ob.nz = value
+    property irn:
+        def __get__(self): return <long> self.ob.irn
+        def __set__(self, long value): self.ob.irn = <MUMPS_INT*> value
+    property jcn:
+        def __get__(self): return <long> self.ob.jcn
+        def __set__(self, long value): self.ob.jcn = <MUMPS_INT*> value
+    property a:
+        def __get__(self): return <long> self.ob.a
+        def __set__(self, long value): self.ob.a = <ZMUMPS_COMPLEX*> value
+
+    property nz_loc:
+        def __get__(self): return self.ob.nz_loc
+        def __set__(self, value): self.ob.nz_loc = value
+    property irn_loc:
+        def __get__(self): return <long> self.ob.irn_loc
+        def __set__(self, long value): self.ob.irn_loc = <MUMPS_INT*> value
+    property jcn_loc:
+        def __get__(self): return <long> self.ob.jcn_loc
+        def __set__(self, long value): self.ob.jcn_loc = <MUMPS_INT*> value
+    property a_loc:
+        def __get__(self): return <long> self.ob.a_loc
+        def __set__(self, long value): self.ob.a_loc = <ZMUMPS_COMPLEX*> value
+
+    property nelt:
+        def __get__(self): return self.ob.nelt
+        def __set__(self, value): self.ob.nelt = value
+    property eltptr:
+        def __get__(self): return <long> self.ob.eltptr
+        def __set__(self, long value): self.ob.eltptr = <MUMPS_INT*> value
+    property eltvar:
+        def __get__(self): return <long> self.ob.eltvar
+        def __set__(self, long value): self.ob.eltvar = <MUMPS_INT*> value
+    property a_elt:
+        def __get__(self): return <long> self.ob.a_elt
+        def __set__(self, long value): self.ob.a_elt = <ZMUMPS_COMPLEX*> value
+
+    property perm_in:
+        def __get__(self): return <long> self.ob.perm_in
+        def __set__(self, long value): self.ob.perm_in = <MUMPS_INT*> value
+
+    property sym_perm:
+        def __get__(self): return <long> self.ob.sym_perm
+        def __set__(self, long value): self.ob.sym_perm = <MUMPS_INT*> value
+    property uns_perm:
+        def __get__(self): return <long> self.ob.uns_perm
+        def __set__(self, long value): self.ob.uns_perm = <MUMPS_INT*> value
+
+    property colsca:
+        def __get__(self): return <long> self.ob.colsca
+        def __set__(self, long value): self.ob.colsca = <ZMUMPS_REAL*> value
+    property rowsca:
+        def __get__(self): return <long> self.ob.rowsca
+        def __set__(self, long value): self.ob.rowsca = <ZMUMPS_REAL*> value
+
+    property rhs:
+        def __get__(self): return <long> self.ob.rhs
+        def __set__(self, long value): self.ob.rhs = <ZMUMPS_COMPLEX*> value
+    property redrhs:
+        def __get__(self): return <long> self.ob.redrhs
+        def __set__(self, long value): self.ob.redrhs = <ZMUMPS_COMPLEX*> value
+    property rhs_sparse:
+        def __get__(self): return <long> self.ob.rhs_sparse
+        def __set__(self, long value): self.ob.rhs_sparse = <ZMUMPS_COMPLEX*> value
+    property sol_loc:
+        def __get__(self): return <long> self.ob.sol_loc
+        def __set__(self, long value): self.ob.sol_loc = <ZMUMPS_COMPLEX*> value
+
+
+    property irhs_sparse:
+        def __get__(self): return <long> self.ob.irhs_sparse
+        def __set__(self, long value): self.ob.irhs_sparse = <MUMPS_INT*> value
+    property irhs_ptr:
+        def __get__(self): return <long> self.ob.irhs_ptr
+        def __set__(self, long value): self.ob.irhs_ptr = <MUMPS_INT*> value
+    property isol_loc:
+        def __get__(self): return <long> self.ob.isol_loc
+        def __set__(self, long value): self.ob.isol_loc = <MUMPS_INT*> value
+
+    property nrhs:
+        def __get__(self): return self.ob.nrhs
+        def __set__(self, value): self.ob.nrhs = value
+    property lrhs:
+        def __get__(self): return self.ob.lrhs
+        def __set__(self, value): self.ob.lrhs = value
+    property lredrhs:
+        def __get__(self): return self.ob.lredrhs
+        def __set__(self, value): self.ob.lredrhs = value
+    property nz_rhs:
+        def __get__(self): return self.ob.nz_rhs
+        def __set__(self, value): self.ob.nz_rhs = value
+    property lsol_loc:
+        def __get__(self): return self.ob.lsol_loc
+        def __set__(self, value): self.ob.lsol_loc = value
+
+    property schur_mloc:
+        def __get__(self): return self.ob.schur_mloc
+        def __set__(self, value): self.ob.schur_mloc = value
+    property schur_nloc:
+        def __get__(self): return self.ob.schur_nloc
+        def __set__(self, value): self.ob.schur_nloc = value
+    property schur_lld:
+        def __get__(self): return self.ob.schur_lld
+        def __set__(self, value): self.ob.schur_lld = value
+
+
+    property mblock:
+        def __get__(self): return self.ob.mblock
+        def __set__(self, value): self.ob.mblock = value
+    property nblock:
+        def __get__(self): return self.ob.nblock
+        def __set__(self, value): self.ob.nblock = value
+    property nprow:
+        def __get__(self): return self.ob.nprow
+        def __set__(self, value): self.ob.nprow = value
+    property npcol:
+        def __get__(self): return self.ob.npcol
+        def __set__(self, value): self.ob.npcol = value
+
+    property info:
+        def __get__(self):
+            cdef MUMPS_INT[:] view = self.ob.info
+            return view
+    property infog:
+        def __get__(self):
+            cdef MUMPS_INT[:] view = self.ob.infog
+            return view
+
+    property rinfo:
+        def __get__(self):
+            cdef ZMUMPS_REAL[:] view = self.ob.rinfo
+            return view
+    property rinfog:
+        def __get__(self):
+            cdef ZMUMPS_REAL[:] view = self.ob.rinfog
+            return view
+
+    property deficiency:
+        def __get__(self): return self.ob.deficiency
+        def __set__(self, value): self.ob.deficiency = value
+    property pivnul_list:
+        def __get__(self): return <long> self.ob.pivnul_list
+        def __set__(self, long value): self.ob.pivnul_list = <MUMPS_INT*> value
+    property mapping:
+        def __get__(self): return <long> self.ob.mapping
+        def __set__(self, long value): self.ob.mapping = <MUMPS_INT*> value
+
+    property size_schur:
+        def __get__(self): return self.ob.size_schur
+        def __set__(self, value): self.ob.size_schur = value
+    property listvar_schur:
+        def __get__(self): return <long> self.ob.listvar_schur
+        def __set__(self, long value): self.ob.listvar_schur = <MUMPS_INT*> value
+    property schur:
+        def __get__(self): return <long> self.ob.schur
+        def __set__(self, long value): self.ob.schur = <ZMUMPS_COMPLEX*> value
+
+    property instance_number:
+        def __get__(self): return self.ob.instance_number
+        def __set__(self, value): self.ob.instance_number = value
+    property wk_user:
+        def __get__(self): return <long> self.ob.wk_user
+        def __set__(self, long value): self.ob.wk_user = <ZMUMPS_COMPLEX*> value
+
+    property version_number:
+        def __get__(self):
+            return (<bytes> self.ob.version_number).decode('ascii')
+
+    property ooc_tmpdir:
+        def __get__(self):
+            return (<bytes> self.ob.ooc_tmpdir).decode('ascii')
+        def __set__(self, char *value):
+            strncpy(self.ob.ooc_tmpdir, value, sizeof(self.ob.ooc_tmpdir))
+    property ooc_prefix:
+        def __get__(self):
+            return (<bytes> self.ob.ooc_prefix).decode('ascii')
+        def __set__(self, char *value):
+            strncpy(self.ob.ooc_prefix, value, sizeof(self.ob.ooc_prefix))
+
+    property write_problem:
+        def __get__(self):
+            return (<bytes> self.ob.write_problem).decode('ascii')
+        def __set__(self, char *value):
+            strncpy(self.ob.write_problem, value, sizeof(self.ob.write_problem))
+
+    property lwk_user:
+        def __get__(self): return self.ob.lwk_user
+        def __set__(self, value): self.ob.lwk_user = value
+
+def zmumps_c(ZMUMPS_STRUC_C s not None):
+    with nogil:
+        c_zmumps_c(&s.ob)
+
+__version__ = (<bytes> MUMPS_VERSION).decode('ascii')
+
+########################################################################
+# Casting routines.
+########################################################################
+
+def cast_array(arr):
+    """Convert numpy array to corresponding cffi pointer.
+
+    The user is entirely responsible for ensuring the data is contiguous
+    and for holding a reference to the underlying array.
+    """
+    dtype = arr.dtype
+    if dtype == 'i':
+        return arr.__array_interface__['data'][0]
+    elif dtype == 'd':
+        return arr.__array_interface__['data'][0]
+    elif dtype == 'D':
+        return arr.__array_interface__['data'][0]
+    else:
+        raise ValueError("Unknown dtype %r" % dtype)

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,11 @@ setup(
             sources=['mumps/_dmumps.pyx'],
             libraries=['dmumps', 'mumps_common'],
         ),
+        Extension(
+            'mumps._zmumps',
+            sources=['mumps/_zmumps.pyx'],
+            libraries=['zmumps', 'mumps_common'],
+        ),
     ],
     install_requires=['mpi4py'],
     classifiers=[


### PR DESCRIPTION
Add a wrapper to ZMUMPS (double complex arithmetic) and an example (solving 1D Helmholtz equation) for testing the ZMUMPS wrapper. Update setup.py, __init__.py, and dsimpletest.py (replace 5 by n)

Fixes #11.